### PR TITLE
keccak: fix build

### DIFF
--- a/.github/workflows/keccak.yml
+++ b/.github/workflows/keccak.yml
@@ -45,10 +45,12 @@ jobs:
           override: true
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-        working-directory: ${{ github.workflow }}
+  # TODO(tarcieri): fix issues with `packed_simd_2`
+  # See: https://github.com/RustCrypto/sponges/runs/6581411295?check_suite_focus=true
+  #minimal-versions:
+  #  uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+  #  with:
+  #      working-directory: ${{ github.workflow }}
 
   test:
     needs: set-msrv
@@ -81,7 +83,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2022-04-01
           override: true
       - run: cargo check --features simd
       - run: cargo test --features simd


### PR DESCRIPTION
`packed_simd_2` no longer builds on nightly:

https://github.com/rust-lang/packed_simd/issues/343

This commit pins the nightly version for now, and disables the `minimal-versions` check since it's not customizable and requires the latest nightly.