### PR TITLE
Use portable_simd instead of deprecate packed_simd

### DIFF
--- a/.github/workflows/keccak.yml
+++ b/.github/workflows/keccak.yml
@@ -45,12 +45,10 @@ jobs:
           override: true
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
-  # TODO(tarcieri): fix issues with `packed_simd_2`
-  # See: https://github.com/RustCrypto/sponges/runs/6581411295?check_suite_focus=true
-  #minimal-versions:
-  #  uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-  #  with:
-  #      working-directory: ${{ github.workflow }}
+  minimal-versions:
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     needs: set-msrv
@@ -83,7 +81,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-04-01
+          toolchain: nightly
           override: true
       - run: cargo check --features simd
       - run: cargo test --features simd

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -11,8 +11,7 @@ categories = ["cryptography", "no-std"]
 readme = "README.md"
 
 [dependencies]
-packed_simd = { version = "0.3.7", package = "packed_simd_2", optional = true }
 
 [features]
 no_unroll = []
-simd = ["packed_simd"]
+simd = []

--- a/keccak/benches/mod.rs
+++ b/keccak/benches/mod.rs
@@ -1,4 +1,6 @@
 #![feature(test)]
+#![cfg_attr(feature = "simd", feature(portable_simd))]
+
 extern crate keccak;
 extern crate test;
 

--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -37,9 +37,7 @@
 //! [2]: https://docs.rs/tiny-keccak
 #![no_std]
 #![allow(non_upper_case_globals)]
-
-#[cfg(feature = "simd")]
-extern crate packed_simd;
+#![cfg_attr(feature = "simd", feature(portable_simd))]
 
 use core::{
     convert::TryInto,
@@ -150,8 +148,7 @@ impl_keccak!(f1600, u64);
 #[cfg(feature = "simd")]
 /// SIMD implementations for Keccak-f1600 sponge function
 pub mod simd {
-    #[cfg(feature = "simd")]
-    pub use packed_simd::{u64x2, u64x4, u64x8};
+    pub use core::simd::{u64x2, u64x4, u64x8};
     use {keccak_p, LaneSize, PLEN};
 
     macro_rules! impl_lanesize_simd_u64xn {
@@ -164,7 +161,7 @@ pub mod simd {
                 }
 
                 fn rotate_left(self, n: u32) -> Self {
-                    self.rotate_left(Self::splat(n.into()))
+                    self << Self::splat(n.into()) | self >> Self::splat((64 - n).into())
                 }
             }
         };


### PR DESCRIPTION
@tarcieri I just migrated to use portable_simd.

EDIT: Just force-pushed to remove an unnecessary change, which I didnot spot before.