### PR TITLE
keccak v0.1.2

### DIFF
--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.1 (2018-03-27)
+## 0.1.2 (2022-05-24)
+### Changed
+- Implement `simd` feature with  `portable_simd` instead of deprecated `packed_simd` ([#16])
+
+[#16]: https://github.com/RustCrypto/sponges/pull/16
+
+## 0.1.1 (2022-05-24)
 ### Added
 - Generic keccak-p and keccak-f {200, 400, 800} ([#7])
 - f1600x{2, 4, 8} ([#8])

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak"
-version = "0.1.1"
+version = "0.1.2"
 description = """
 Pure Rust implementation of the Keccak sponge function including the keccak-f
 and keccak-p variants

--- a/keccak/README.md
+++ b/keccak/README.md
@@ -7,9 +7,18 @@
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
 
-Pure Rust implementation of the [Keccak Sponge Function][1].
+Pure Rust implementation of the [Keccak Sponge Function][1] including the keccak-f
+and keccak-p variants.
 
 [Documentation][docs-link]
+
+## About
+
+This crate implements the core Keccak sponge function, upon which many other
+cryptographic functions are built.
+
+For the SHA-3 family including the SHAKE XOFs, see the [`sha3`] crate, which
+is built on this crate.
 
 ## Minimum Supported Rust Version
 
@@ -54,3 +63,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [1]: https://keccak.team/keccak.html
+[`sha3`]: https://github.com/RustCrypto/hashes/tree/master/sha3


### PR DESCRIPTION
### Changed
- Implement `simd` feature with  `portable_simd` instead of deprecated `packed_simd` ([#16])

[#16]: https://github.com/RustCrypto/sponges/pull/16