### PR TITLE
keccak: rename `f1600_armv8_sha3_asm`

### DIFF
--- a/keccak/README.md
+++ b/keccak/README.md
@@ -22,7 +22,7 @@ is built on this crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.41** or higher by default, or **1.59** with the `asm` feature enabled.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.

--- a/keccak/src/armv8.rs
+++ b/keccak/src/armv8.rs
@@ -4,7 +4,7 @@
 /// Adapted from the Keccak-f1600 implementation in the XKCP/K12.
 /// see <https://github.com/XKCP/K12/blob/df6a21e6d1f34c1aa36e8d702540899c97dba5a0/lib/ARMv8Asha3/KeccakP-1600-ARMv8Asha3.S#L69>
 #[target_feature(enable = "sha3")]
-pub unsafe fn f1600_asm(state: &mut [u64; 25]) {
+pub unsafe fn f1600_armv8_sha3_asm(state: &mut [u64; 25]) {
     core::arch::asm!("
         // Read state
         ld1.1d {{ v0- v3}}, [x0], #32

--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -53,7 +53,7 @@ mod unroll;
 mod armv8;
 
 #[cfg(all(target_arch = "aarch64", feature = "asm"))]
-pub use armv8::f1600_asm;
+pub use armv8::f1600_armv8_sha3_asm;
 
 #[cfg(all(target_arch = "aarch64", feature = "asm"))]
 cpufeatures::new!(armv8_sha3_intrinsics, "sha3");
@@ -159,7 +159,7 @@ impl_keccak!(f1600, u64);
 #[cfg(all(target_arch = "aarch64", feature = "asm"))]
 pub fn f1600(state: &mut [u64; PLEN]) {
     if armv8_sha3_intrinsics::get() {
-        unsafe { f1600_asm(state) }
+        unsafe { f1600_armv8_sha3_asm(state) }
     } else {
         keccak_p(state, u64::KECCAK_F_ROUND_COUNT);
     }


### PR DESCRIPTION
Include the target architecture and feature in the name of the function.