### PR TITLE
keccak: 2018 edition upgrade, lints, docs

### DIFF
--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/RustCrypto/sponges/tree/master/keccak"
 keywords = ["crypto", "sponge", "keccak", "keccak-f", "keccak-p"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
+edition = "2018"
 
 [features]
 asm = []       # Use optimized assembly when available (currently only ARMv8)

--- a/keccak/src/armv8.rs
+++ b/keccak/src/armv8.rs
@@ -185,9 +185,9 @@ mod tests {
         ];
 
         let mut state = [0u64; 25];
-        unsafe { keccak_f1600(&mut state) };
+        unsafe { f1600_armv8_sha3_asm(&mut state) };
         assert_eq!(state, state_first);
-        unsafe { keccak_f1600(&mut state) };
+        unsafe { f1600_armv8_sha3_asm(&mut state) };
         assert_eq!(state, state_second);
     }
 }

--- a/keccak/src/unroll.rs
+++ b/keccak/src/unroll.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 #[cfg(not(feature = "no_unroll"))]
 #[macro_export]
 macro_rules! unroll5 {

--- a/keccak/src/unroll.rs
+++ b/keccak/src/unroll.rs
@@ -1,5 +1,4 @@
-#![allow(missing_docs)]
-
+/// unroll5
 #[cfg(not(feature = "no_unroll"))]
 #[macro_export]
 macro_rules! unroll5 {
@@ -12,6 +11,7 @@ macro_rules! unroll5 {
     };
 }
 
+/// unroll5
 #[cfg(feature = "no_unroll")]
 #[macro_export]
 macro_rules! unroll5 {
@@ -20,6 +20,7 @@ macro_rules! unroll5 {
     }
 }
 
+/// unroll24
 #[cfg(not(feature = "no_unroll"))]
 #[macro_export]
 macro_rules! unroll24 {
@@ -51,6 +52,7 @@ macro_rules! unroll24 {
     };
 }
 
+/// unroll24
 #[cfg(feature = "no_unroll")]
 #[macro_export]
 macro_rules! unroll24 {


### PR DESCRIPTION
- Bumps the crate's edition to 2018, which is MSRV-compatible.
- Adds a more expansive set of lints
- Adds the `missing_docs` lint, and adds docs where missing
- Fixes tests on ARMv8