### PR TITLE
ascon: 2018 edition upgrade, lints, docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "ascon"
-version = "0.1.4"
+version = "0.2.0-pre"
 dependencies = [
  "byteorder",
 ]

--- a/ascon/Cargo.toml
+++ b/ascon/Cargo.toml
@@ -1,10 +1,18 @@
 [package]
 name = "ascon"
-version = "0.1.4"
-authors = ["quininer kel <quininer@live.com>"]
-description = "A implementation of ASCON authenticated encryption."
-repository = "https://github.com/quininer/ascon"
+version = "0.2.0-pre"
+description = """
+Pure Rust implementation of Ascon, a family of authenticated encryption and
+hashing algorithms designed to be lightweight and easy to implement
+"""
+authors = ["quininer kel <quininer@live.com>", "RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
+documentation = "https://docs.rs/ascon"
+repository = "https://github.com/RustCrypto/sponges/tree/master/ascon"
+keywords = ["crypto", "sponge"]
+categories = ["cryptography", "no-std"]
+readme = "README.md"
+edition = "2018"
 
 [dependencies]
 byteorder = { version = "1.0", default-features = false }

--- a/ascon/README.md
+++ b/ascon/README.md
@@ -64,6 +64,7 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (links)
 
 [RustCrypto]: https://github.com/rustcrypto
+[Ascon]: https://ascon.iaik.tugraz.at/
 [New standard for lightweight cryptography]: https://www.nist.gov/news-events/news/2023/02/nist-selects-lightweight-cryptography-algorithms-protect-small-devices
 [NIST Lightweight Cryptography]: https://csrc.nist.gov/projects/lightweight-cryptography/finalists
 [CAESAR competition]: https://competitions.cr.yp.to/caesar-submissions.html

--- a/ascon/src/ops.rs
+++ b/ascon/src/ops.rs
@@ -1,4 +1,7 @@
-use util::{u64_to_u8, u8_to_u64};
+use crate::{
+    util::{u64_to_u8, u8_to_u64},
+    A, B, KEY_LEN, RATE, S_SIZE,
+};
 
 pub fn permutation(s: &mut [u8], start: usize, rounds: usize) {
     let mut x = [0; 5];
@@ -47,17 +50,17 @@ pub fn permutation(s: &mut [u8], start: usize, rounds: usize) {
 }
 
 pub fn initialization(s: &mut [u8], key: &[u8], nonce: &[u8]) {
-    s[0] = ::KEY_LEN as u8 * 8;
-    s[1] = ::RATE as u8 * 8;
-    s[2] = ::A as u8;
-    s[3] = ::B as u8;
+    s[0] = KEY_LEN as u8 * 8;
+    s[1] = RATE as u8 * 8;
+    s[2] = A as u8;
+    s[3] = B as u8;
 
-    let mut pos = ::S_SIZE - 2 * ::KEY_LEN;
+    let mut pos = S_SIZE - 2 * KEY_LEN;
     s[pos..pos + key.len()].copy_from_slice(key);
-    pos += ::KEY_LEN;
+    pos += KEY_LEN;
     s[pos..pos + nonce.len()].copy_from_slice(nonce);
 
-    permutation(s, 12 - ::A, ::A);
+    permutation(s, 12 - A, A);
 
     for (i, &b) in key.iter().enumerate() {
         s[pos + i] ^= b;
@@ -66,19 +69,19 @@ pub fn initialization(s: &mut [u8], key: &[u8], nonce: &[u8]) {
 
 pub fn finalization(s: &mut [u8], key: &[u8]) {
     for (i, &b) in key.iter().enumerate() {
-        s[::RATE + i] ^= b;
+        s[RATE + i] ^= b;
     }
-    permutation(s, 12 - ::A, ::A);
+    permutation(s, 12 - A, A);
     for (i, &b) in key.iter().enumerate() {
-        s[::S_SIZE - ::KEY_LEN + i] ^= b;
+        s[S_SIZE - KEY_LEN + i] ^= b;
     }
 }
 
 pub fn process_aad(ss: &mut [u8], aa: &[u8], s: usize) {
     for i in 0..s {
-        for j in 0..::RATE {
-            ss[j] ^= aa[i * ::RATE + j];
+        for j in 0..RATE {
+            ss[j] ^= aa[i * RATE + j];
         }
-        permutation(ss, 12 - ::B, ::B);
+        permutation(ss, 12 - B, B);
     }
 }


### PR DESCRIPTION
- Bumps the crate's edition to 2018, which is MSRV-compatible
- Adds a more expansive set of lints
- Adds the `missing_docs` lint, and adds docs where missing