### PR TITLE
ascon: add `no_std` support

### DIFF
--- a/.github/workflows/ascon.yml
+++ b/.github/workflows/ascon.yml
@@ -35,6 +35,28 @@ jobs:
           override: true
       - run: cargo build --benches
 
+  build:
+    needs: set-msrv
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - ${{needs.set-msrv.outputs.msrv}}
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v3
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --no-default-features --target ${{ matrix.target }}
+
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
@@ -56,4 +78,5 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - run: cargo test --no-default-features
       - run: cargo test

--- a/ascon/Cargo.toml
+++ b/ascon/Cargo.toml
@@ -16,3 +16,11 @@ edition = "2018"
 
 [dependencies]
 byteorder = { version = "1.0", default-features = false }
+
+[features]
+default = ["alloc"]
+alloc = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/ascon/src/lib.rs
+++ b/ascon/src/lib.rs
@@ -20,6 +20,7 @@
 //! [NIST Lightweight Cryptography]: https://csrc.nist.gov/projects/lightweight-cryptography/finalists
 //! [CAESAR competition]: https://competitions.cr.yp.to/caesar-submissions.html
 
+#![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
@@ -33,6 +34,10 @@
     unused_qualifications
 )]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
 pub mod aead;
 
 mod util;

--- a/ascon/src/util.rs
+++ b/ascon/src/util.rs
@@ -15,15 +15,3 @@ pub fn u64_to_u8(input: &[u64], output: &mut [u8]) {
         Endian::write_u64(&mut output[(i * 8)..((i + 1) * 8)], b)
     }
 }
-
-pub fn eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        false
-    } else {
-        a.iter()
-            .zip(b)
-            .map(|(x, y)| x ^ y)
-            .fold(0, |sum, next| sum | next)
-            .eq(&0)
-    }
-}


### PR DESCRIPTION
The permutation does not have any `std`/`alloc` dependency.

The current AEAD interface requires `alloc` (though we should migrate it to use the `aead` crate anyway).