### PR TITLE
ascon: remove `byteorder` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,15 +5,6 @@ version = 3
 [[package]]
 name = "ascon"
 version = "0.2.0-pre"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cpufeatures"

--- a/ascon/Cargo.toml
+++ b/ascon/Cargo.toml
@@ -14,9 +14,6 @@ categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2018"
 
-[dependencies]
-byteorder = { version = "1.0", default-features = false }
-
 [features]
 default = ["alloc"]
 alloc = []

--- a/ascon/src/lib.rs
+++ b/ascon/src/lib.rs
@@ -25,6 +25,7 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
+#![forbid(unsafe_code)]
 #![warn(
     clippy::mod_module_files,
     clippy::unwrap_used,

--- a/ascon/src/util.rs
+++ b/ascon/src/util.rs
@@ -1,17 +1,16 @@
-use byteorder::{BigEndian, ByteOrder};
-
-pub type Endian = BigEndian;
+use core::convert::TryInto;
 
 #[inline]
+#[allow(clippy::unwrap_used)]
 pub fn u8_to_u64(input: &[u8], output: &mut [u64]) {
     for (i, b) in output.iter_mut().enumerate() {
-        *b = Endian::read_u64(&input[(i * 8)..((i + 1) * 8)]);
+        *b = u64::from_be_bytes(input[(i * 8)..((i + 1) * 8)].try_into().unwrap());
     }
 }
 
 #[inline]
 pub fn u64_to_u8(input: &[u64], output: &mut [u8]) {
     for (i, &b) in input.iter().enumerate() {
-        Endian::write_u64(&mut output[(i * 8)..((i + 1) * 8)], b)
+        output[(i * 8)..((i + 1) * 8)].copy_from_slice(&b.to_be_bytes())
     }
 }


### PR DESCRIPTION
We can use the support in `core` instead