### PR TITLE
ascon: extract `Ascon` permutation type; MSRV 1.59

### DIFF
--- a/.github/workflows/ascon.yml
+++ b/.github/workflows/ascon.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.59.0
 
   benches:
     runs-on: ubuntu-latest

--- a/ascon/README.md
+++ b/ascon/README.md
@@ -28,7 +28,7 @@ portfolio of the [CAESAR competition].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.41** at a minimum.
+This crate requires **Rust 1.59** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -57,7 +57,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/sponges/actions/workflows/ascon.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/sponges/actions/workflows/ascon.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.59+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/369879-sponges
 


### PR DESCRIPTION
Adds a struct which wraps the permutation state, using const generics as well as `feature(const_generics_defaults)` to express the `A`/`B` parameters for `Ascon(a,b)`.