### PR TITLE
CI: exclude `keccak` from toplevel workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
+exclude = ["keccak"] # TODO(tarcieri): add back to `members` when MSRV >= 1.56
 members = [
     "ascon",
-    "keccak",
+    #"keccak",
 ]

--- a/keccak/Cargo.lock
+++ b/keccak/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cpufeatures",
 ]


### PR DESCRIPTION
The build is failing because `keccak` has a very old MSRV of 1.41, which after merging #40 (which bumped the `ascon` edition to 2021) broke the build because it can't handle the `edition` key.

As a workaround, this excludes `keccak` from the toplevel workspace so it doesn't try to read the `ascon` edition key.

Separately, we should probably bump the `keccak` edition to 2021 as well and release `keccak` v0.2.0, but that is left for future work.