### PR TITLE
ascon: `Key` type alias; cache key in `Ascon` state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,25 +5,3 @@ version = 3
 [[package]]
 name = "ascon"
 version = "0.2.0-pre"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.3"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.137"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"


### PR DESCRIPTION
- Adds a type alias for Ascon keys (16-byte)
- Stores key internally in `struct Ascon` so it doesn't need to be passed separately to `Ascon::finalize`.