### PR TITLE
ascon: use `aead` crate for AEAD API; MSRV 1.60

### DIFF
--- a/.github/workflows/ascon.yml
+++ b/.github/workflows/ascon.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.59.0
+        msrv: 1.60.0
 
   benches:
     runs-on: ubuntu-latest
@@ -56,6 +56,7 @@ jobs:
           target: ${{ matrix.target }}
           override: true
       - run: cargo build --no-default-features --target ${{ matrix.target }}
+      - run: cargo build --no-default-features --target ${{ matrix.target }} --features aead
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
@@ -80,3 +81,4 @@ jobs:
           override: true
       - run: cargo test --no-default-features
       - run: cargo test
+      - run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,64 @@
 version = 3
 
 [[package]]
+name = "aead"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "ascon"
 version = "0.2.0-pre"
+dependencies = [
+ "aead",
+ "hex-literal",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/ascon/Cargo.toml
+++ b/ascon/Cargo.toml
@@ -13,11 +13,21 @@ keywords = ["crypto", "sponge"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
+
+[dependencies]
+aead = { version = "0.5", optional = true, default-features = false }
+subtle = { version = "2", optional = true, default-features = false }
+
+[dev-dependencies]
+hex-literal = "0.3"
 
 [features]
-default = ["alloc"]
-alloc = []
+default = ["aead"]
+alloc = ["aead?/alloc"]
+std = ["aead?/std"]
+
+aead = ["dep:aead", "alloc", "subtle"] # TODO(tarcieri): remove alloc dependency
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ascon/LICENSE-APACHE
+++ b/ascon/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright (c) 2016-2023 quininer kel, RustCrypto Developers
+Copyright [yyyy] [name of copyright owner]
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/ascon/README.md
+++ b/ascon/README.md
@@ -28,7 +28,7 @@ portfolio of the [CAESAR competition].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.59** at a minimum.
+This crate requires **Rust 1.60** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -57,7 +57,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/sponges/actions/workflows/ascon.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/sponges/actions/workflows/ascon.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.59+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/369879-sponges
 

--- a/ascon/benches/bench.rs
+++ b/ascon/benches/bench.rs
@@ -2,28 +2,35 @@
 
 extern crate test;
 
-use ascon::aead;
+use ascon::aead::{AeadInPlace, AsconAead, KeyInit};
+use hex_literal::hex;
 use test::Bencher;
 
-#[bench]
-fn ascon_encrypt_bench(b: &mut Bencher) {
-    let key = [4; 16];
-    let iv = [8; 16];
-    let aad = [3; 16];
-    let message = [99; 1025];
-
-    b.bytes = message.len() as u64;
-    b.iter(|| aead::encrypt(&key, &iv, &message, &aad));
-}
+const KEY: [u8; 16] = [4; 16];
+const NONCE: [u8; 16] = [8; 16];
+const AAD: [u8; 16] = [3; 16];
+const PLAINTEXT: [u8; 1025] = [99; 1025];
+const CIPHERTEXT: [u8; 1025] = hex!("d5cfb4650e0a82b9e86455de588cfd48c4bf240301efbf1981a57f00c5ec31eb9127d5da85fab0bf3c927b9d875cd1f71e0945f0281a0774e890bae1f98d488580c63e19972d73b6df19773503b0d8f0317727b8ab7681e15237eec369e8ea2915695d6f03f44541ea28f737574d5c7277361636a0a246fbc8c4b6764ef642b9a15211e11f5059fd08d173e4a9fff4cc55389d04a392f0a12dbccce67439e967bb8f39887b078cd68eaa8fd5a3c3b7299536c50a35b7871ab612417fdd1313527cbc82591d20417f2ef3dc37dc1298b32677daac9e79cf28307ceb886aea42694322ac5e978405fff9df6b9da86c83661fa165c957b830dc85350bb41ae6a6f9ee7c713d47b6277b54c64d0ceefd41945f23cfe4f0ba0ea39ba7c829c308ab53591817adeda57c4d3858fff07f57ec4100905e8568e855f61d558f7cffc3dc47b4e2ab9b90053caef52bede5871c5839b33f48e8822dbca59e96532ded31e809d901de72d65d5112ac067f7135670445bdec7e9f41287190dd091f906d6d98b6d15aa3fa475a2b4f99bc0e12e9c057140308a73572dcabad2e2140103028c075e9da74d92177aaea9d1899dace0ee8f4a9edfa9c4abc39a4b6239a2ea3841af1f90af884d10ef43b48924cba8474cb0162c8204acab4647cb680e9b64fb77e4d2195f63dd45e6c21b637db5c15101a72259e5af940ce9e5c0fe0b4affefef059e2982c32dfe50c0aefee368f15867ab2ff205fa855a895a0379b5678f432e25fd884771873acf6ee72fe4cf02c13843239b3114ff9e9bfebc44618bffc731b272cf08e627e47d759f1ae63191892d493a19fb54b96dd2132e416612d4e4a3bb536d0470c151c998a9ce5a44883ac395efa23e201734ef6a9e7ac1dade6a48fff8445e39a38157b5263cf9e52abf8cb604be9f1ed7ebe85e10933ab1f3e0546c17bbf7561233d7f95b32f8086fdbb06948af5a0ffd06dd47e89c3f4a419cc5b34300a76a542aeeae716563204f68f880cac077855297150fd217d6185116d542b64ce1319712760bf61fa1b6b52c8e9feb609bf6caa07b41ed80c7423cbe5390ec9851a2629d9d307971515c0a1696b0d4d52deabab089b945326b1e62a6ec5eb2cf2c58a5af0404962923a0c8605b6d55fd899765b193db8f5a849ecab478e187476779cf5f08d38a812b14ddff6143870ce5d9afc3e2eda91624067654940856421f5a8e0f6e3eefe888bd11c9364a29e2821374a1550e888359230ba863424746c793708e0ba23be967fa527ee5989eaf48541928e594ea846d67d5a6a56aa886be7b693d662cd675c786687c0d870bf19ab7564fb0b87bc6bba157ae04f482fca52858f8ff600141efa24f2f29cb0b8e222d88d9bfd9e60818474e55cc2b11e70125a956934c75cad4207f83b372c501ca7864bf8d387d0f81ec1cc872ff180");
+const TAG: [u8; 16] = hex!("17d7dca595adcaaddf537a1e9fd02854");
 
 #[bench]
 fn ascon_decrypt_bench(b: &mut Bencher) {
-    let key = [4; 16];
-    let iv = [8; 16];
-    let aad = [3; 16];
-    let message = [99; 1025];
-    let (ciphertext, tag) = aead::encrypt(&key, &iv, &message, &aad);
+    let aead = AsconAead::<12, 8>::new(&KEY.into());
+    b.bytes = CIPHERTEXT.len() as u64;
+    b.iter(|| {
+        let mut buffer = CIPHERTEXT;
+        aead.decrypt_in_place_detached(&NONCE.into(), &AAD, &mut buffer, &TAG.into())
+            .unwrap();
+    });
+}
 
-    b.bytes = message.len() as u64;
-    b.iter(|| aead::decrypt(&key, &iv, &ciphertext, &aad, &tag));
+#[bench]
+fn ascon_encrypt_bench(b: &mut Bencher) {
+    let aead = AsconAead::<12, 8>::new(&KEY.into());
+    b.bytes = PLAINTEXT.len() as u64;
+    b.iter(|| {
+        let mut buffer = PLAINTEXT;
+        aead.encrypt_in_place_detached(&NONCE.into(), &AAD, &mut buffer)
+            .unwrap();
+    });
 }

--- a/ascon/src/lib.rs
+++ b/ascon/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
@@ -17,8 +18,11 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "aead")]
 pub mod aead;
+
+#[cfg(feature = "aead")]
+pub use crate::aead::AsconAead;
 
 use core::convert::TryInto;
 


### PR DESCRIPTION
Impls the standard AEAD API from the `aead` crate.

Eventually we can split this API out into a separate crate, e.g. `ascon-aead`, but for now this just gets things working initially.

Uses weak/namespaced features which requires MSRV 1.60.