### PR TITLE
ascon v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "ascon"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "aead",
  "hex-literal",

--- a/ascon/CHANGELOG.md
+++ b/ascon/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 (2023-02-25)
+### Added
+-  `no_std` support ([#36])
+- `Ascon` permutation type ([#39])
+- `Key` type alias ([#42])
+- `Nonce` type alias ([#43])
+
+### Changed
+- 2021 edition ([#40])
+- Use `aead` crate for AEAD API ([#44])
+- MSRV 1.60 ([#44])
+
+### Removed
+- `byteorder` dependency ([#37])
+
+[#36]: https://github.com/RustCrypto/sponges/pull/36
+[#37]: https://github.com/RustCrypto/sponges/pull/37
+[#39]: https://github.com/RustCrypto/sponges/pull/39
+[#40]: https://github.com/RustCrypto/sponges/pull/40
+[#42]: https://github.com/RustCrypto/sponges/pull/42
+[#43]: https://github.com/RustCrypto/sponges/pull/43
+[#44]: https://github.com/RustCrypto/sponges/pull/44
+
+## 0.1.4 (2017-03-27)
+
+## 0.1.3 (2016-11-13)
+
+## 0.1.2 (2016-11-01)
+
+## 0.1.1 (2016-11-01)
+
+## 0.1.0 (2016-07-26)

--- a/ascon/Cargo.toml
+++ b/ascon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon"
-version = "0.2.0-pre"
+version = "0.2.0"
 description = """
 Pure Rust implementation of Ascon, a family of authenticated encryption and
 hashing algorithms designed to be lightweight and easy to implement
@@ -9,7 +9,7 @@ authors = ["quininer kel <quininer@live.com>", "RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/ascon"
 repository = "https://github.com/RustCrypto/sponges/tree/master/ascon"
-keywords = ["crypto", "sponge"]
+keywords = ["aead", "crypto", "sponge"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"

--- a/ascon/README.md
+++ b/ascon/README.md
@@ -17,9 +17,9 @@ hashing algorithms designed to be lightweight and easy to implement.
 Ascon is a family of lightweight algorithms built on a core permutation
 algorithm. These algorithms include:
 
-- Authenticated Encryption with Associated Data (AEAD)
-- Hash functions (HASH) and extendible-output functions (XOF)
-- Pseudo-random functions (PRF) and message authentication codes (MAC)
+- [x] Authenticated Encryption with Associated Data (AEAD)
+- [ ] Hash functions (HASH) and extendible-output functions (XOF)
+- [ ] Pseudo-random functions (PRF) and message authentication codes (MAC)
 
 Ascon has been selected as [new standard for lightweight cryptography] in the
 [NIST Lightweight Cryptography] competition, and has also been selected as the


### PR DESCRIPTION
### Added
-  `no_std` support ([#36])
- `Ascon` permutation type ([#39])
- `Key` type alias ([#42])
- `Nonce` type alias ([#43])

### Changed
- 2021 edition ([#40])
- Use `aead` crate for AEAD API ([#44])
- MSRV 1.60 ([#44])

### Removed
- `byteorder` dependency ([#37])

[#36]: https://github.com/RustCrypto/sponges/pull/36
[#37]: https://github.com/RustCrypto/sponges/pull/37
[#39]: https://github.com/RustCrypto/sponges/pull/39
[#40]: https://github.com/RustCrypto/sponges/pull/40
[#42]: https://github.com/RustCrypto/sponges/pull/42
[#43]: https://github.com/RustCrypto/sponges/pull/43
[#44]: https://github.com/RustCrypto/sponges/pull/44