### PR TITLE
ascon v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ascon"
-version = "0.3.0-pre"
+version = "0.3.0"

--- a/ascon/CHANGELOG.md
+++ b/ascon/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2023-03-17)
+### Added
+- `State` type and permutation from `ascon-core` crate ([#49])
+- `no_unroll` feature
+
+### Removed
+- AEAD API and `aead` dependency
+  The implementation of the AEAD API is provided by `ascon-aead`.
+- `Ascon`, `Key`, `Nonce` types
+- `alloc`, `std`, and `aead` features
+
+[#49]: https://github.com/RustCrypto/sponges/pull/49
+
 ## 0.2.0 (2023-02-25)
 ### Added
 -  `no_std` support ([#36])

--- a/ascon/Cargo.toml
+++ b/ascon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = "Pure rust implementation of the Ascon permutation"
 authors = [
     "Sebastian Ramacher <sebastian.ramacher@ait.ac.at>",


### PR DESCRIPTION
### Added
- `State` type and permutation from `ascon-core` crate (https://github.com/RustCrypto/sponges/pull/49)
- `no_unroll` feature

### Removed
- AEAD API and `aead` dependency
  The implementation of the AEAD API is provided by `ascon-aead`.
- `Ascon`, `Key`, `Nonce` types
- `alloc`, `std`, and `aead` features