### PR TITLE
ascon: drop MSRV to 1.56

### DIFF
--- a/.github/workflows/ascon.yml
+++ b/.github/workflows/ascon.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.60.0
+        msrv: 1.56.0
 
   build:
     needs: set-msrv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ascon"
-version = "0.3.0"
+version = "0.3.1-pre"

--- a/ascon/Cargo.toml
+++ b/ascon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon"
-version = "0.3.0"
+version = "0.3.1-pre"
 description = "Pure rust implementation of the Ascon permutation"
 authors = [
     "Sebastian Ramacher <sebastian.ramacher@ait.ac.at>",
@@ -13,7 +13,7 @@ keywords = ["Ascon", "crypto", "permutation"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.56"
 
 [features]
 no_unroll = [] # Do not unroll loops for binary size reduction

--- a/ascon/README.md
+++ b/ascon/README.md
@@ -29,7 +29,7 @@ portfolio of the [CAESAR competition].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.60** at a minimum.
+This crate requires **Rust 1.56** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -58,7 +58,7 @@ dual licensed as above, without any additional terms or conditions.
 [build-image]: https://github.com/RustCrypto/sponges/actions/workflows/ascon.yml/badge.svg
 [build-link]: https://github.com/RustCrypto/sponges/actions/workflows/ascon.yml
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/369879-sponges
 

--- a/ascon/src/lib.rs
+++ b/ascon/src/lib.rs
@@ -404,7 +404,8 @@ mod tests {
         );
         let bytes = state.as_bytes();
 
-        let state2 = State::try_from(bytes.as_slice());
+        // test TryFrom<&[u8]>
+        let state2 = State::try_from(&bytes[..]);
         assert_eq!(state2.expect("try_from bytes").x, state.x);
 
         let state2 = State::from(&bytes);


### PR DESCRIPTION
MSRV was raised for `ascon` in c8b07a46c86b240d3ce9c5e75a4f23117a874e19. After the merge of `ascon-core`, 1.56 provides all required features.