### PR TITLE
keccak v0.1.4

### DIFF
--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.4 (2023-05-04)
+### Added
+- `keccak_p` fns for `[200, 400, 800, 1600]` ([#55])
+
+### Changed
+- 2018 edition upgrade ([#32])
+
+[#32]: https://github.com/RustCrypto/sponges/pull/32
+[#55]: https://github.com/RustCrypto/sponges/pull/55
+
 ## 0.1.3 (2022-11-14)
 ### Added
 - ARMv8 SHA3 ASM intrinsics implementation for `keccak_f1600` ([#23])

--- a/keccak/Cargo.lock
+++ b/keccak/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "cpufeatures",
 ]

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 description = """
 Pure Rust implementation of the Keccak sponge function including the keccak-f
 and keccak-p variants
@@ -17,7 +17,7 @@ edition = "2018"
 [features]
 asm = []       # Use optimized assembly when available (currently only ARMv8)
 no_unroll = [] # Do no unroll loops for binary size reduction
-simd = []      # Use core::simd (WARNING: requires Nigthly)
+simd = []      # Use core::simd (nightly-only)
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 cpufeatures = "0.2"


### PR DESCRIPTION
### Added
- `keccak_p` fns for `[200, 400, 800, 1600]` ([#55])

### Changed
- 2018 edition upgrade ([#32])

[#32]: https://github.com/RustCrypto/sponges/pull/32
[#55]: https://github.com/RustCrypto/sponges/pull/55