### PR TITLE
keccak: replace CI tests on MIPS with PPC32

### DIFF
--- a/.github/workflows/keccak.yml
+++ b/.github/workflows/keccak.yml
@@ -92,7 +92,7 @@ jobs:
           - i686-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
-          - mips-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
         features:
           - no_unroll
           - 'NO_FEATURE'


### PR DESCRIPTION
`mips-unknown-linux-gnu` is now a Tier 3 target: rust-lang/rust#115218.

This means we can't use it for cross tests anymore since std is no longer built for it.

This commit replaces it with `powerpc-unknown-linux-gnu`, a big endian Tier 2 target.