### PR TITLE
keccak: don't test `simd` feature in `minimal-versions` workflow

### DIFF
--- a/.github/workflows/keccak.yml
+++ b/.github/workflows/keccak.yml
@@ -47,6 +47,7 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
+        stable-cmd: cargo hack test --release --feature-powerset --skip simd # `simd` requires nightly
 
   test:
     needs: set-msrv


### PR DESCRIPTION
It requires `nightly`, whereas the tests are run under `stable`.

The `simd` feature itself is already tested in the `test-simd` job.