### PR TITLE
Revert "Update Cargo.lock"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"


### PR DESCRIPTION
This reverts commit 3a9a29ef77f4718b6a385d08779d098dded51ef7.

This update is higher than the current Ascon MSRV and broke the build