### PR TITLE
keccak v0.1.5

### DIFF
--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.5 (2024-01-12)
+### Changed
+- Enable ARMv8 ASM backend for `p1600` ([#68])
+
+[#68]: https://github.com/RustCrypto/sponges/pull/68
+
 ## 0.1.4 (2023-05-04)
 ### Added
 - `keccak_p` fns for `[200, 400, 800, 1600]` ([#55])

--- a/keccak/Cargo.lock
+++ b/keccak/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cpufeatures",
 ]

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 description = """
 Pure Rust implementation of the Keccak sponge function including the keccak-f
 and keccak-p variants


### PR DESCRIPTION
### Changed
- Enable ARMv8 ASM backend for `p1600` ([#68])

[#68]: https://github.com/RustCrypto/sponges/pull/68