### PR TITLE
Cargo.lock: bump `zeroize` to v1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,6 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"


### PR DESCRIPTION
This is possible now that we've bumped `ascon`'s MSRV to 1.60