### PR TITLE
cargo: point `repository` metadata to clonable URLs

### DIFF
--- a/ascon/Cargo.toml
+++ b/ascon/Cargo.toml
@@ -8,7 +8,8 @@ authors = [
 ]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/ascon"
-repository = "https://github.com/RustCrypto/sponges/tree/master/ascon"
+homepage = "https://github.com/RustCrypto/sponges/tree/master/ascon"
+repository = "https://github.com/RustCrypto/sponges"
 keywords = ["Ascon", "crypto", "permutation"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -8,7 +8,8 @@ and keccak-p variants
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/keccak"
-repository = "https://github.com/RustCrypto/sponges/tree/master/keccak"
+homepage = "https://github.com/RustCrypto/sponges/tree/master/keccak"
+repository = "https://github.com/RustCrypto/sponges"
 keywords = ["crypto", "sponge", "keccak", "keccak-f", "keccak-p"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"


### PR DESCRIPTION
This tweaks the `repository` fields in Cargo metadata in order to use the correct (i.e. git clonable) URL. The existing GitHub webUI URLs for each package have been retained and moved to `homepage` fields.