### PR TITLE
keccak_p: improve efficiency of Theta phase

### DIFF
--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -254,9 +254,9 @@ pub fn keccak_p<L: LaneSize>(state: &mut [L; PLEN], round_count: usize) {
         });
 
         unroll5!(x, {
+            let t1 = array[(x + 4) % 5];
+            let t2 = array[(x + 1) % 5].rotate_left(1);
             unroll5!(y, {
-                let t1 = array[(x + 4) % 5];
-                let t2 = array[(x + 1) % 5].rotate_left(1);
                 state[5 * y + x] ^= t1 ^ t2;
             });
         });


### PR DESCRIPTION
`t1` and `t2` in the second step of Theta phase can be computed outside of the y loop as they rely only on x.