### PR TITLE
Bump MSRV to 1.81

### DIFF
--- a/.github/workflows/ascon.yml
+++ b/.github/workflows/ascon.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.60.0
+        msrv: 1.81.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/keccak.yml
+++ b/.github/workflows/keccak.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.60.0
+        msrv: 1.81.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.71.0
+          toolchain: 1.82.0
           components: clippy
       - run: cargo clippy --all -- -D warnings
 

--- a/ascon/Cargo.toml
+++ b/ascon/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["Ascon", "crypto", "permutation"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.81"
 
 [dependencies]
 zeroize = { version = "1.6.0", default-features = false, optional=true }

--- a/ascon/README.md
+++ b/ascon/README.md
@@ -29,7 +29,7 @@ portfolio of the [CAESAR competition].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.60** at a minimum.
+This crate requires **Rust 1.81** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["crypto", "sponge", "keccak", "keccak-f", "keccak-p"]
 categories = ["cryptography", "no-std"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.81"
 
 [features]
 asm = []       # Use optimized assembly when available (currently only ARMv8)

--- a/keccak/README.md
+++ b/keccak/README.md
@@ -22,7 +22,7 @@ is built on this crate.
 
 ## Minimum Supported Rust Version
 
-Rust **1.60** or higher.
+Rust **1.81** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.

--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -273,9 +273,7 @@ pub fn keccak_p<L: LaneSize>(state: &mut [L; PLEN], round_count: usize) {
         unroll5!(y_step, {
             let y = 5 * y_step;
 
-            unroll5!(x, {
-                array[x] = state[y + x];
-            });
+            array.copy_from_slice(&state[y..][..5]);
 
             unroll5!(x, {
                 let t1 = !array[(x + 1) % 5];


### PR DESCRIPTION
1.81 is the new MSRV baseline for our downstream crates, so I think we can have a similar MSRV bump for these crates as well despite the fact that they technically can work with older Rust versions. This also should future-proof as a bit against potential bumps in `libc` which recently has bumped MSRV to 1.63.