### PR TITLE
cpufeatures optional, default feature

### DIFF
--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -17,9 +17,10 @@ edition = "2021"
 rust-version = "1.81"
 
 [features]
-asm = []       # Use optimized assembly when available (currently only ARMv8)
-no_unroll = [] # Do no unroll loops for binary size reduction
-simd = []      # Use core::simd (nightly-only)
+default = ["cpufeatures"]
+asm = []                  # Use optimized assembly when available (currently only ARMv8)
+no_unroll = []            # Do no unroll loops for binary size reduction
+simd = []                 # Use core::simd (nightly-only)
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-cpufeatures = "0.2"
+cpufeatures = { version = "0.2", optional = true }


### PR DESCRIPTION
Closes #86 

After this PR is accepted output is -> 

### By default

Command
```
cargo tree -p keccak 
```

Output 
```
keccak v0.2.0-pre.0 (/Users/username/path/to/sponges/keccak)
└── cpufeatures v0.2.16
    └── libc v0.2.164
```


### No-default-features

Command
```
cargo tree -p keccak --no-default-features
```

Output
```
keccak v0.2.0-pre.0 (/Users/username/path/to/sponges/keccak)
```
