### PR TITLE
Use doc_cfg in place of removed doc_auto_cfg feature.

### DIFF
--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -37,7 +37,7 @@
 //! [2]: https://docs.rs/tiny-keccak
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "simd", feature(portable_simd))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/138907
