### PR TITLE
bash-f: tweak benchmarks

### DIFF
--- a/bash-f/benches/mod.rs
+++ b/bash-f/benches/mod.rs
@@ -6,31 +6,6 @@ use test::Bencher;
 
 #[bench]
 fn bench_bash_f(b: &mut Bencher) {
-    let mut state = [0u64; STATE_WORDS];
-    b.iter(|| {
-        bash_f(test::black_box(&mut state));
-        test::black_box(&state);
-    });
-}
-
-#[bench]
-fn bench_bash_f_10_rounds(b: &mut Bencher) {
-    let mut state = [0u64; STATE_WORDS];
-    b.iter(|| {
-        for _ in 0..10 {
-            bash_f(test::black_box(&mut state));
-        }
-        test::black_box(&state);
-    });
-}
-
-#[bench]
-fn bench_bash_f_100_rounds(b: &mut Bencher) {
-    let mut state = [0u64; STATE_WORDS];
-    b.iter(|| {
-        for _ in 0..100 {
-            bash_f(test::black_box(&mut state));
-        }
-        test::black_box(&state);
-    });
+    let state = &mut [0u64; STATE_WORDS];
+    b.iter(|| bash_f(test::black_box(state)));
 }


### PR DESCRIPTION
The benches with 10 and 100 iterations are not really useful since they produce the same result as `bench_bash_f` but multiplied by the number of iterations.