### PR TITLE
keccak: replace `keccak_soft_compact` with `keccak_backend_soft="compact"`

### DIFF
--- a/.github/workflows/keccak.yml
+++ b/.github/workflows/keccak.yml
@@ -84,7 +84,7 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --features parallel
       - run: cargo test --release --target ${{ matrix.target }} --features parallel
       - env:
-          RUSTFLAGS: '-Dwarnings --cfg keccak_soft_compact'
+          RUSTFLAGS: '-Dwarnings --cfg keccak_backend_soft="compact"'
         run: cargo test --release --target ${{ matrix.target }}
       - env:
           RUSTFLAGS: '-Dwarnings --cfg keccak_backend="soft"'
@@ -131,7 +131,7 @@ jobs:
       - run: cargo miri test --target ${{ matrix.target }}
       - run: cargo miri test --target ${{ matrix.target }} --features parallel
       - env:
-          RUSTFLAGS: '-Dwarnings --cfg keccak_soft_compact'
+          RUSTFLAGS: '-Dwarnings --cfg keccak_backend_soft="compact"'
         run: cargo miri test --release --target ${{ matrix.target }} --features parallel
       - env:
           RUSTFLAGS: '-Dwarnings --cfg keccak_backend="simd128"'

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -33,7 +33,7 @@ unused_qualifications = "warn"
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(keccak_soft_compact)',
+    'cfg(keccak_backend_soft, values("compact"))',
     'cfg(keccak_backend, values("aarch64_sha3", "simd128", "simd256", "simd512", "soft"))',
 ]
 

--- a/keccak/README.md
+++ b/keccak/README.md
@@ -54,12 +54,14 @@ keccak::Keccak::new().with_f1600(|f1600| {
 You can modify crate using the following configuration flags:
 
 - `keccak_backend`: select the specified backend. Supported values:
-  `aarch64_sha3`, `simd128`, `simd256`, `simd512`, `soft`.
-- `keccak_soft_compact`: do not unroll loops in the software backend.
-  Reduces performance, but results in a more compact binary code.
+    - `aarch64_sha3`: AArch64-specific backend based on the `sha3` extension.
+    - `simd128/256/512`: backend based on the portable SIMD API. Requires Nightly compiler.
+    - `soft`: portable software backend.
+- `keccak_backend_soft="compact"`: control software backend implementation. Supported values:
+    - `compact`: do not unroll loops. Reduces performance, but results in a more compact binary code.
 
 The flags can be enabled using `RUSTFLAGS` environment variable
-(e.g. `RUSTFLAGS="--cfg aes_compact"`) or by modifying `.cargo/config`.
+(e.g. `RUSTFLAGS='--cfg keccak_backend="soft"'`) or by modifying `.cargo/config.toml`.
 
 ## License
 

--- a/keccak/src/backends/soft.rs
+++ b/keccak/src/backends/soft.rs
@@ -52,7 +52,7 @@ impl_lanesize!(u64, F1600_ROUNDS);
 #[rustfmt::skip]
 macro_rules! unroll5 {
     ($var: ident, $body: block) => {
-        #[cfg(not(keccak_soft_compact))]
+        #[cfg(not(keccak_backend_soft = "compact"))]
         {
             { const $var: usize = 0; $body; }
             { const $var: usize = 1; $body; }
@@ -60,7 +60,7 @@ macro_rules! unroll5 {
             { const $var: usize = 3; $body; }
             { const $var: usize = 4; $body; }
         }
-        #[cfg(keccak_soft_compact)]
+        #[cfg(keccak_backend_soft = "compact")]
         {
             for $var in 0..5 $body
         }
@@ -70,7 +70,7 @@ macro_rules! unroll5 {
 #[rustfmt::skip]
 macro_rules! unroll24 {
     ($var: ident, $body: block) => {
-        #[cfg(not(keccak_soft_compact))]
+        #[cfg(not(keccak_backend_soft = "compact"))]
         {
             { const $var: usize = 0; $body; }
             { const $var: usize = 1; $body; }
@@ -97,7 +97,7 @@ macro_rules! unroll24 {
             { const $var: usize = 22; $body; }
             { const $var: usize = 23; $body; }
         }
-        #[cfg(keccak_soft_compact)]
+        #[cfg(keccak_backend_soft = "compact")]
         {
             for $var in 0..24 $body
         }


### PR DESCRIPTION
This would allow to extend configuration knobs for the software backend in future and would be more consisted with potential similar knobs for other backends.