### PR TITLE
Release ascon v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ascon"
-version = "0.5.0-rc.0"
+version = "0.5.0"
 
 [[package]]
 name = "bash-f"

--- a/ascon/CHANGELOG.md
+++ b/ascon/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2026-04-22)
+### Changed
+- Edition changed to 2024 and MSRV bumped to 1.85 ([#89])
+- Improved performance of permutations ([#118])
+- Replaced the `State` struct with free-standing permutation functions ([#122])
+
+### Removed
+- `zeroize` crate feature ([#122])
+
+[#89]: https://github.com/RustCrypto/sponges/pull/89
+[#118]: https://github.com/RustCrypto/sponges/pull/118
+[#122]: https://github.com/RustCrypto/sponges/pull/122
+
 ## 0.4.0 (2023-07-27)
 ### Added
 - `zeroize` feature ([#57])

--- a/ascon/Cargo.toml
+++ b/ascon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon"
-version = "0.5.0-rc.0"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/ascon/README.md
+++ b/ascon/README.md
@@ -11,7 +11,7 @@ Pure Rust implementation of the [Ascon] permutation, winner of the
 [NIST Lightweight Cryptography] competition.
 
 This is a low-level crate used for implementation of higher-level agorithms,
-e.g. [`ascon-hash256`] and [`ascon-aead128`].
+e.g. [`ascon-hash256`], [`ascon-xof128`], and [`ascon-aead128`].
 
 ## Minimum Supported Rust Version
 
@@ -51,6 +51,7 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (links)
 
 [`ascon-aead128`]: https://docs.rs/ascon-aead128
+[`ascon-xof128`]: https://docs.rs/ascon-xof128
 [`ascon-hash256`]: https://docs.rs/ascon-hash256
 [RustCrypto]: https://github.com/rustcrypto
 [Ascon]: https://ascon.iaik.tugraz.at


### PR DESCRIPTION
### Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#89])
- Improved performance of permutations ([#118])
- Replaced the `State` struct with free-standing permutation functions ([#122])

### Removed
- `zeroize` crate feature ([#122])

[#89]: https://github.com/RustCrypto/sponges/pull/89
[#118]: https://github.com/RustCrypto/sponges/pull/118
[#122]: https://github.com/RustCrypto/sponges/pull/122