### PR TITLE
Release keccak v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,16 +27,16 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -45,12 +45,12 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.1 (UNRELEASED)
+## 0.2.1 (2026-08-05)
 ### Fixed
 - Warning on softfloat AArch64 targets by not enabling `aarch64_sha3` backend on them ([#126])
 

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Fixed
- Warning on softfloat AArch64 targets by not enabling `aarch64_sha3` backend on them ([#126])

[#126]: https://github.com/RustCrypto/sponges/pull/126