### PR TITLE
Release keccak v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### 0.2.2 (2026-08-20)
+### 0.2.2 (2026-08-21)
 ### Changed
 - Improved performance of software backend on some targets ([#129])
 

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### 0.2.2 (UNRELEASED)
+### 0.2.2 (2026-08-20)
 ### Changed
 - Improved performance of software backend on some targets ([#129])
 

--- a/keccak/Cargo.toml
+++ b/keccak/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Changed
- Improved performance of software backend on some targets ([#129])

### Removed
- `keccak_backend_soft = "compact"` configuration flag and explicit loop unrolling  ([#130])

[#129]: https://github.com/RustCrypto/sponges/pull/129
[#130]: https://github.com/RustCrypto/sponges/pull/130